### PR TITLE
#2384: Update POM, helm chart and install script versions for 1.3.2 release

### DIFF
--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -7,7 +7,7 @@ if [ $# -ge 1 ] ; then
 fi
 
 NS=kernel
-CHART_VERSION=1.3.2-rc.1-develop
+CHART_VERSION=1.3.2-develop
 
 echo Create $NS namespace
 kubectl create ns $NS

--- a/helm/auditmanager/Chart.yaml
+++ b/helm/auditmanager/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: auditmanager
 description: A Helm chart for MOSIP Auditmanager module
 type: application
-version: 1.3.2-rc.1-develop
+version: 1.3.2-develop
 appVersion: ""
 dependencies:
   - name: common

--- a/helm/auditmanager/values.yaml
+++ b/helm/auditmanager/values.yaml
@@ -46,8 +46,8 @@ service:
   externalTrafficPolicy: Cluster
 image:
   registry: docker.io
-  repository: mosipid/kernel-auditmanager-service
-  tag: 1.3.2.-rc.1
+  repository: mosipqa/kernel-auditmanager-service
+  tag: 1.3.x
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images

--- a/kernel/kernel-auditmanager-api/pom.xml
+++ b/kernel/kernel-auditmanager-api/pom.xml
@@ -7,7 +7,7 @@
 	<groupId>io.mosip.kernel</groupId>
 
 	<artifactId>kernel-auditmanager-api</artifactId>
-	<version>1.3.2-rc.1</version>
+	<version>1.3.2-SNAPSHOT</version>
      <properties>		
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
@@ -22,7 +22,7 @@
 		<maven-shade-plugin.version>2.3</maven-shade-plugin.version>
 		<central.publishing.maven.plugin.version>0.7.0</central.publishing.maven.plugin.version>
 
-     	<kernel.core.version>1.3.1-rc.1</kernel.core.version>
+     	<kernel.core.version>1.3.1-SNAPSHOT</kernel.core.version>
      	
 	 	<jacoco.maven.plugin.version>0.8.11</jacoco.maven.plugin.version>
 		<sonar.coverage.exclusions>**/dto/**,**/constant/**,**/config/**,**/httpfilter/**,**/cache/**,**/entity/**,**/model/**,**/exception/**,**/repository/**,**/request/**,**/spi/**,"**/proxy/**","**/AuditManagerBootApplication.java

--- a/kernel/kernel-auditmanager-service/pom.xml
+++ b/kernel/kernel-auditmanager-service/pom.xml
@@ -5,7 +5,7 @@
 	<groupId>io.mosip.kernel</groupId>
 
 	<artifactId>kernel-auditmanager-service</artifactId>
-	<version>1.3.2-rc.1</version>
+	<version>1.3.2-SNAPSHOT</version>
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
@@ -21,12 +21,12 @@
 		<central.publishing.maven.plugin.version>0.7.0</central.publishing.maven.plugin.version>
 
 		<!-- spring -->
-		<kernel.core.version>1.3.1-rc.1</kernel.core.version>
-		<kernel.applicant-type.version>1.3.1-rc.1</kernel.applicant-type.version>
-		<kernel.audit-api.version>1.3.2-rc.1</kernel.audit-api.version>
-		<kernel.logger.version>1.3.1-rc.1</kernel.logger.version>
+		<kernel.core.version>1.3.1-SNAPSHOT</kernel.core.version>
+		<kernel.applicant-type.version>1.3.1-SNAPSHOT</kernel.applicant-type.version>
+		<kernel.audit-api.version>1.3.2-SNAPSHOT</kernel.audit-api.version>
+		<kernel.logger.version>1.3.1-SNAPSHOT</kernel.logger.version>
 		<kernel.auth-adapter.version>1.3.0</kernel.auth-adapter.version>
-		<kernel-dataaccess-hibernate-version>1.3.1-rc.1</kernel-dataaccess-hibernate-version>
+		<kernel-dataaccess-hibernate-version>1.3.1-SNAPSHOT</kernel-dataaccess-hibernate-version>
 
 		<sonar.coverage.exclusions>**/dto/**,**/constant/**,**/config/**,**/httpfilter/**,**/cache/**,**/entity/**,**/model/**,**/exception/**,**/repository/**,**/request/**,**/spi/**,"**/proxy/**","**/AuditManagerBootApplication.java"</sonar.coverage.exclusions>
 		<sonar.cpd.exclusions>**/dto/**,**/entity/**,**/config/**</sonar.cpd.exclusions>

--- a/kernel/pom.xml
+++ b/kernel/pom.xml
@@ -2,7 +2,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
-	<version>1.3.2-rc.1</version>
+	<version>1.3.2-SNAPSHOT</version>
 	<groupId>io.mosip.kernel</groupId>
 	<artifactId>audit-manager</artifactId>
 	<packaging>pom</packaging>


### PR DESCRIPTION
Convert rc versions to SNAPSHOT in pom.xml, update Chart.yaml and install.sh chart_version to 1.3.2-develop, and point values.yaml image repository to mosipqa with tag 1.3.x.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release Updates**
  * Updated the Audit Manager deployment to the `1.3.2-develop` chart release.
  * Updated the container image to the `1.3.x` development stream.
  * Advanced application components and kernel references from release-candidate versions to snapshot builds.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->