### PR TITLE
Fix sonar analysis failing with "No plugin found for prefix 'sonar'"

### DIFF
--- a/kernel/kernel-auditmanager-api/pom.xml
+++ b/kernel/kernel-auditmanager-api/pom.xml
@@ -15,6 +15,7 @@
 		<maven.compiler.source>21</maven.compiler.source>
 		<maven.compiler.target>21</maven.compiler.target>
 		<maven.compiler.version>3.8.0</maven.compiler.version>
+		<maven.sonar.plugin.version>3.7.0.1746</maven.sonar.plugin.version>
 
 		<maven.jar.plugin.version>3.0.2</maven.jar.plugin.version>
 		<maven.war.plugin.version>3.1.0</maven.war.plugin.version>
@@ -247,4 +248,26 @@
 		<name>Audit manager api</name>
 		<description>Audit manager api for Mosip</description>
         <url>https://github.com/mosip/audit-manager</url>
+	<profiles>
+		<profile>
+			<id>sonar</id>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.sonarsource.scanner.maven</groupId>
+						<artifactId>sonar-maven-plugin</artifactId>
+						<version>${maven.sonar.plugin.version}</version>
+						<executions>
+							<execution>
+								<phase>verify</phase>
+								<goals>
+									<goal>sonar</goal>
+								</goals>
+							</execution>
+						</executions>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+	</profiles>
 	</project>

--- a/kernel/kernel-auditmanager-service/pom.xml
+++ b/kernel/kernel-auditmanager-service/pom.xml
@@ -13,6 +13,7 @@
 		<maven.compiler.source>21</maven.compiler.source>
 		<maven.compiler.target>21</maven.compiler.target>
 		<maven.compiler.version>3.8.0</maven.compiler.version>
+		<maven.sonar.plugin.version>3.7.0.1746</maven.sonar.plugin.version>
 
 		<maven.jar.plugin.version>3.0.2</maven.jar.plugin.version>
 		<maven.war.plugin.version>3.1.0</maven.war.plugin.version>
@@ -367,6 +368,26 @@
 							<outputDir>${project.build.directory}</outputDir>
 							<skip>false</skip>
 						</configuration>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+		<profile>
+			<id>sonar</id>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.sonarsource.scanner.maven</groupId>
+						<artifactId>sonar-maven-plugin</artifactId>
+						<version>${maven.sonar.plugin.version}</version>
+						<executions>
+							<execution>
+								<phase>verify</phase>
+								<goals>
+									<goal>sonar</goal>
+								</goals>
+							</execution>
+						</executions>
 					</plugin>
 				</plugins>
 			</build>


### PR DESCRIPTION
## Problem

The `sonar_analysis` job fails in about 22 seconds ([example run](https://github.com/mosip/audit-manager/actions/runs/31687674315/job/94409838433)):

```
[ERROR] No plugin found for prefix 'sonar' in the current project and in the plugin groups
[org.sonatype.central, pl.project13.maven, org.jacoco,
 org.apache.maven.plugins, org.codehaus.mojo]
```

Maven never reaches SonarCloud — it cannot resolve what `sonar:sonar` refers to. Every other job in the run passes, so this is a code-quality-gate outage rather than a broken build.

## Cause

The reusable workflow `mosip/kattu/.github/workflows/maven-sonar-analysis.yml@master-java21` invokes the scanner **by prefix**:

```
cd ./kernel/ && mvn -Psonar -U -B verify sonar:sonar ... -s $GITHUB_WORKSPACE/settings.xml
```

The `settings.xml` it generates inline has no `<pluginGroups>` block, so resolving the `sonar` prefix depends entirely on `org.sonarsource.scanner.maven` being declared in the POM of each project in the reactor.

`kernel/pom.xml` **does** declare `sonar-maven-plugin` in its `sonar` profile. The catch is that the two modules it aggregates — `kernel-auditmanager-api` and `kernel-auditmanager-service` — **declare no `<parent>`**. They are standalone POMs referenced only as `<module>` entries, so they inherit nothing from the aggregator, that profile included.

The reactor order in the log confirms it — the aggregator builds *last*:

```
[INFO] Audit manager api        [jar]
[INFO] Auditmanager service     [jar]
[INFO] audit-manager            [pom]
```

`Audit manager api` is built first and the prefix cannot be resolved there.

## Fix

Declare the plugin in both module POMs, matching the pattern already in `kernel/pom.xml` and keeping the repo's existing `maven.sonar.plugin.version` of `3.7.0.1746`.

`kernel-auditmanager-service` already had a `<profiles>` section, so the sonar profile is appended to it rather than adding a second element — its `openapi-doc-generate-profile` is untouched.

44 added lines, no deletions, no other files touched.

## Verification

JDK 21 / Maven 3.9.9, against a `settings.xml` reproducing the one the workflow generates (no `pluginGroups`).

**Before** — both modules reproduce the CI error:

```
kernel-auditmanager-api:     No plugin found for prefix 'sonar'
kernel-auditmanager-service: No plugin found for prefix 'sonar'
```

**After** — both resolve:

```
Name: SonarQube Scanner for Maven
Version: 3.7.0.1746
Goal Prefix: sonar
[INFO] BUILD SUCCESS
```

And the existing profile on the service module survives — `mvn help:all-profiles` lists both:

```
Profile Id: openapi-doc-generate-profile (Active: false, Source: pom)
Profile Id: sonar                        (Active: false, Source: pom)
```

## Note on what is not proven here

The sonar job is gated `if: github.event_name != 'pull_request'`, so it will **not** run on this PR. The SonarCloud upload itself needs the `SONAR_TOKEN`/`ORG_KEY` secrets and can only be confirmed after merge to `release-1.3.x`. What this PR proves is that prefix resolution — the thing that fails today — is fixed.

A central alternative would be adding `<pluginGroups>` to the `settings.xml` generated in kattu, which would fix every MOSIP repo hitting this in one change. That has a much wider blast radius, so this PR takes the self-contained per-POM route.
